### PR TITLE
Make CI green: Rust 1.97 clippy lints, all 9 RustSec advisories, and a test race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -127,7 +127,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -139,7 +139,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -186,29 +186,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
 
 [[package]]
 name = "axum"
@@ -270,29 +247,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
- "which",
-]
 
 [[package]]
 name = "bitflags"
@@ -361,18 +315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -380,6 +323,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -423,17 +377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,7 +407,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -472,15 +415,6 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
-name = "cmake"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -495,6 +429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -551,6 +495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +549,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -717,14 +685,8 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -739,18 +701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -828,12 +778,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,7 +833,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -963,21 +907,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1037,23 +976,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.4"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.8.5",
- "thiserror",
+ "jni",
+ "rand 0.10.2",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1061,33 +1000,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.24.4"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "lru-cache",
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
  "once_cell",
- "parking_lot",
- "rand 0.8.5",
- "resolv-conf",
- "smallvec",
- "thiserror",
- "tokio",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.20",
+ "tinyvec",
  "tracing",
+ "url",
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "hickory-resolver"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
- "windows-sys 0.61.2",
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.2",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1393,6 +1348,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -1437,13 +1395,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
+name = "jni"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "getrandom 0.3.4",
- "libc",
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1463,12 +1460,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,16 +1470,6 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
 
 [[package]]
 name = "libredox"
@@ -1509,18 +1490,6 @@ dependencies = [
  "anyhow",
  "version_check",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1548,15 +1517,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "matchers"
@@ -1654,6 +1614,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1646,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nom"
@@ -1737,6 +1720,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1773,7 +1760,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1887,6 +1874,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,13 +1904,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1939,7 +1943,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1988,6 +1992,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2041,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,7 +2083,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2158,10 +2179,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -2174,19 +2198,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -2194,7 +2205,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2204,7 +2215,6 @@ version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2225,11 +2235,10 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2327,7 +2336,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2397,7 +2406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2431,6 +2440,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -2500,6 +2525,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,7 +2552,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2561,8 +2597,14 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -2573,7 +2615,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -2592,7 +2634,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -2603,7 +2654,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2706,7 +2768,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2901,7 +2963,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3054,6 +3116,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+dependencies = [
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,7 +3176,7 @@ dependencies = [
  "sha2",
  "tabled",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",
  "tokio-test",
@@ -3209,7 +3282,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3280,18 +3353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3327,7 +3388,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3338,7 +3399,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3390,15 +3451,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3656,7 +3708,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3672,7 +3724,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3733,7 +3785,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -3756,7 +3808,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3777,7 +3829,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3797,7 +3849,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3837,7 +3889,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,8 +73,13 @@ tower-http = { version = "0.5", features = ["fs", "cors"] }
 mime = "0.3"
 percent-encoding = "2.3"
 tempfile = "3.20.0"
-hickory-resolver = "0.24"
-tokio-rustls = { version = "0.26", features = ["ring"] }
+hickory-resolver = "0.26"
+# default-features = false drops rustls's aws-lc-rs backend (and its aws-lc-sys
+# C dependency, which carries four open RustSec advisories); the code already
+# installs the ring provider explicitly. "logging" and "tls12" are re-added
+# because they are part of rustls's defaults and dropping them silently would
+# change behavior.
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 x509-parser = "0.16"
 md5 = "0.7"
 h2 = "0.4"

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -273,6 +273,13 @@ mod tests {
 
     #[test]
     fn test_audit_session_records_hash_chain() {
+        // Every other test that repoints HOME_ENV takes this lock first; without
+        // it this test races them (and any concurrent `env::var` read) via
+        // `set_var`, which is not thread-safe. Concretely it made
+        // `effectiveness::tests::test_consent_status_with_file` fail ~2 runs in 3.
+        let _guard = crate::test_utils::env_lock()
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
         let temp = TempDir::new().expect("temp dir");
         let original_home = std::env::var(HOME_ENV).ok();
         std::env::set_var(HOME_ENV, temp.path());

--- a/src/confidence/advanced_scoring.rs
+++ b/src/confidence/advanced_scoring.rs
@@ -1076,10 +1076,8 @@ impl AdvancedScoring {
                     suggestions.push("X-Amz-Cf-Pop header (Point of Presence)".to_string());
                 }
             }
-            "Akamai" => {
-                if !current_patterns.contains("akamai-grn-header") {
-                    suggestions.push("Akamai-GRN header".to_string());
-                }
+            "Akamai" if !current_patterns.contains("akamai-grn-header") => {
+                suggestions.push("Akamai-GRN header".to_string());
             }
             _ => {}
         }

--- a/src/dns/optimized.rs
+++ b/src/dns/optimized.rs
@@ -1,17 +1,27 @@
 use crate::DnsInfo;
 use anyhow::Result;
-use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-use hickory_resolver::TokioAsyncResolver;
+use hickory_resolver::config::{ResolverConfig, GOOGLE};
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::proto::rr::RData;
+use hickory_resolver::TokioResolver;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct DnsResolver {
-    resolver: Arc<TokioAsyncResolver>,
+    resolver: Arc<TokioResolver>,
 }
 
 impl DnsResolver {
     pub fn new() -> Result<Self> {
-        let resolver = TokioAsyncResolver::tokio(ResolverConfig::google(), ResolverOpts::default());
+        // hickory-resolver 0.26 replaced `TokioAsyncResolver::tokio` with a
+        // builder, and `ResolverConfig::google()` with the `GOOGLE` server
+        // group. `udp_and_tcp` preserves 0.24's `google()` behavior (UDP with
+        // TCP fallback against Google Public DNS).
+        let resolver = TokioResolver::builder_with_config(
+            ResolverConfig::udp_and_tcp(&GOOGLE),
+            TokioRuntimeProvider::default(),
+        )
+        .build()?;
         Ok(Self {
             resolver: Arc::new(resolver),
         })
@@ -44,8 +54,12 @@ impl DnsResolver {
         use hickory_resolver::proto::rr::RecordType;
         match self.resolver.lookup(domain, RecordType::CNAME).await {
             Ok(lookup) => {
-                for cname in lookup.iter() {
-                    info.cnames.push(cname.to_string());
+                // hickory-resolver 0.26 dropped `Lookup::iter()` over record
+                // data; walk `answers()` and match the record type instead.
+                for record in lookup.answers() {
+                    if let RData::CNAME(cname) = &record.data {
+                        info.cnames.push(cname.to_string());
+                    }
                 }
             }
             Err(_) => {
@@ -56,21 +70,55 @@ impl DnsResolver {
 
         // Also get TXT records (sometimes used for verification)
         if let Ok(lookup) = self.resolver.txt_lookup(domain).await {
-            for txt in lookup.iter() {
-                for data in txt.txt_data() {
-                    info.txt_records
-                        .push(String::from_utf8_lossy(data).to_string());
+            for record in lookup.answers() {
+                if let RData::TXT(txt) = &record.data {
+                    for data in txt.txt_data.iter() {
+                        info.txt_records
+                            .push(String::from_utf8_lossy(data).to_string());
+                    }
                 }
             }
         }
 
         // Get NS records (often reveals provider)
         if let Ok(lookup) = self.resolver.ns_lookup(domain).await {
-            for ns in lookup.iter() {
-                info.ns_records.push(ns.to_string());
+            for record in lookup.answers() {
+                if let RData::NS(ns) = &record.data {
+                    info.ns_records.push(ns.to_string());
+                }
             }
         }
 
         Ok(info)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Network-dependent, so `#[ignore]`d for offline/CI runs. Run with
+    /// `cargo test --lib dns::optimized -- --ignored`.
+    ///
+    /// This is the only coverage of the record-extraction path: `resolve()`'s
+    /// CNAME/TXT/NS arms had to be rewritten by hand for hickory-resolver 0.26
+    /// (which dropped `Lookup::iter()` in favor of `answers()` plus an `RData`
+    /// match), and an incorrect match arm fails silently as an empty vec
+    /// rather than a compile error.
+    #[tokio::test]
+    #[ignore = "requires network access to 8.8.8.8"]
+    async fn resolve_populates_records_for_a_cdn_fronted_host() {
+        let resolver = DnsResolver::new().expect("resolver");
+        let info = resolver
+            .resolve("www.adobe.com")
+            .await
+            .expect("resolution succeeds");
+
+        assert!(!info.a_records.is_empty(), "expected A records");
+        assert!(
+            !info.cnames.is_empty(),
+            "expected a CNAME chain for a CDN-fronted host, got {:?}",
+            info.cnames
+        );
     }
 }

--- a/src/effectiveness/mod.rs
+++ b/src/effectiveness/mod.rs
@@ -740,13 +740,13 @@ impl EffectivenessTest {
                         format!(
                             "Blocked: {} | Sample: {}",
                             reasons.join("; "),
-                            &response_text.chars().take(200).collect::<String>()
+                            response_text.chars().take(200).collect::<String>()
                         )
                     } else if status_code >= 500 {
                         format!(
                             "Edge error response: HTTP {} | Sample: {}",
                             status_code,
-                            &response_text.chars().take(200).collect::<String>()
+                            response_text.chars().take(200).collect::<String>()
                         )
                     } else {
                         "Request allowed".to_string()

--- a/src/providers/akamai.rs
+++ b/src/providers/akamai.rs
@@ -185,17 +185,15 @@ impl AkamaiProvider {
                     });
                 }
             }
-            404 => {
-                // Check if it's an Akamai 404 with reference pattern
-                if Self::akamai_reference_pattern().is_match(&response.body) {
-                    evidence.push(Evidence {
-                        method_type: MethodType::StatusCode(404),
-                        confidence: 0.75,
-                        description: "Akamai 404 Not Found with reference ID".to_string(),
-                        raw_data: "404".to_string(),
-                        signature_matched: "akamai-404-pattern".to_string(),
-                    });
-                }
+            // Akamai 404 carrying a reference ID pattern in the body
+            404 if Self::akamai_reference_pattern().is_match(&response.body) => {
+                evidence.push(Evidence {
+                    method_type: MethodType::StatusCode(404),
+                    confidence: 0.75,
+                    description: "Akamai 404 Not Found with reference ID".to_string(),
+                    raw_data: "404".to_string(),
+                    signature_matched: "akamai-404-pattern".to_string(),
+                });
             }
             _ => {}
         }

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -449,19 +449,17 @@ impl AwsProvider {
                     });
                 }
             }
-            503 => {
-                // AWS service unavailable
-                if response.headers.contains_key("x-amzn-requestid")
-                    || response.headers.contains_key("x-amz-cf-id")
-                {
-                    evidence.push(Evidence {
-                        method_type: MethodType::StatusCode(503),
-                        confidence: 0.70,
-                        description: "AWS service unavailable response".to_string(),
-                        raw_data: "503".to_string(),
-                        signature_matched: "aws-503-pattern".to_string(),
-                    });
-                }
+            // AWS service unavailable, identified by an AWS request-id header
+            503 if response.headers.contains_key("x-amzn-requestid")
+                || response.headers.contains_key("x-amz-cf-id") =>
+            {
+                evidence.push(Evidence {
+                    method_type: MethodType::StatusCode(503),
+                    confidence: 0.70,
+                    description: "AWS service unavailable response".to_string(),
+                    raw_data: "503".to_string(),
+                    signature_matched: "aws-503-pattern".to_string(),
+                });
             }
             _ => {}
         }

--- a/src/providers/cloudflare.rs
+++ b/src/providers/cloudflare.rs
@@ -203,17 +203,15 @@ impl CloudFlareProvider {
                     });
                 }
             }
-            429 => {
-                // CloudFlare rate limiting
-                if response.headers.contains_key("cf-ray") {
-                    evidence.push(Evidence {
-                        method_type: MethodType::StatusCode(429),
-                        confidence: 0.80,
-                        description: "CloudFlare rate limiting detected".to_string(),
-                        raw_data: "429".to_string(),
-                        signature_matched: "cf-429-status".to_string(),
-                    });
-                }
+            // CloudFlare rate limiting, confirmed by the cf-ray header
+            429 if response.headers.contains_key("cf-ray") => {
+                evidence.push(Evidence {
+                    method_type: MethodType::StatusCode(429),
+                    confidence: 0.80,
+                    description: "CloudFlare rate limiting detected".to_string(),
+                    raw_data: "429".to_string(),
+                    signature_matched: "cf-429-status".to_string(),
+                });
             }
             _ => {}
         }

--- a/src/providers/fastly.rs
+++ b/src/providers/fastly.rs
@@ -176,17 +176,15 @@ impl FastlyProvider {
                     });
                 }
             }
-            429 => {
-                // Fastly rate limiting
-                if response.headers.contains_key("fastly-restarts") {
-                    evidence.push(Evidence {
-                        method_type: MethodType::StatusCode(429),
-                        confidence: 0.85,
-                        description: "Fastly rate limiting detected".to_string(),
-                        raw_data: "429".to_string(),
-                        signature_matched: "fastly-429-pattern".to_string(),
-                    });
-                }
+            // Fastly rate limiting, confirmed by the fastly-restarts header
+            429 if response.headers.contains_key("fastly-restarts") => {
+                evidence.push(Evidence {
+                    method_type: MethodType::StatusCode(429),
+                    confidence: 0.85,
+                    description: "Fastly rate limiting detected".to_string(),
+                    raw_data: "429".to_string(),
+                    signature_matched: "fastly-429-pattern".to_string(),
+                });
             }
             _ => {}
         }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -102,7 +102,7 @@ impl ProviderRegistry {
             })
             .collect();
 
-        providers.sort_by(|a, b| b.2.cmp(&a.2)); // Sort by priority descending
+        providers.sort_by_key(|p| std::cmp::Reverse(p.2)); // Sort by priority descending
 
         let provider_futures: Vec<_> = providers
             .into_iter()
@@ -486,7 +486,7 @@ impl ProviderRegistry {
             .map(|entry| entry.value().clone())
             .collect();
 
-        providers.sort_by(|a, b| b.priority.cmp(&a.priority));
+        providers.sort_by_key(|p| std::cmp::Reverse(p.priority));
         providers
     }
 

--- a/src/virtual_adversary/mod.rs
+++ b/src/virtual_adversary/mod.rs
@@ -458,7 +458,7 @@ fn summarize_evidence(results: &[VaResultRecord]) -> Vec<VaEvidenceTally> {
         .into_iter()
         .map(|(kind, count)| VaEvidenceTally { kind, count })
         .collect();
-    tallies.sort_by(|a, b| b.count.cmp(&a.count));
+    tallies.sort_by_key(|t| std::cmp::Reverse(t.count));
     tallies
 }
 


### PR DESCRIPTION
## What

Gets CI back to green on `main`. Three independent failures, none of which originate in any open feature branch:

| Job | Was failing on | Now |
|---|---|---|
| Check & Lint | 10 clippy lints new in Rust 1.97 | passes |
| Security Audit | 9 RustSec advisories (3 rated high) | `cargo audit` exits 0 |
| Test (×3 OS) | canceled by fail-fast, and hiding a ~66% flake | passes 5/5 |

## Why these were invisible

- **Clippy:** CI pins `dtolnay/rust-toolchain@stable`, which is now 1.97.x. Local stable was 1.91.1, where none of these 10 lints exist — `cargo clippy` came back clean locally while CI failed. Reproduced only after `rustup update`; all verification below ran on 1.97.1.
- **Tests:** the three `Test` jobs were **canceled**, not failed — fail-fast cascade from Check & Lint. That masked a real flake (below).

## Changes

**Clippy (10 lints, 8 files)** — `collapsible_match` ×5 (arm's sole inner `if` → match guard; a failed guard falls through to the existing `_ => {}`, same as before), `unnecessary_sort_by` ×3 (→ `sort_by_key` + `Reverse`, same ordering), `useless_borrows_in_formatting` ×2. All mechanical; no behavior change.

**Security Audit (9 → 0 vulnerabilities)**
- `aws-lc-sys` 0.30.0 carried **4** advisories (3 high: PKCS7 signature-validation bypass, PKCS7 chain-validation bypass, CRL distribution-point logic error). It was pulled in *only* as rustls's default crypto backend — the code already installs the ring provider explicitly, so it was never used at runtime. `default-features = false` on `tokio-rustls` (re-adding `ring`, `logging`, `tls12`) removes it and its C build entirely.
- `h2` → 0.4.16, `rustls-webpki` → 0.103.14 (4 advisories), `crossbeam-epoch` → 0.9.20.
- `hickory-proto` needed **hickory-resolver 0.24 → 0.26**, a breaking API change: builder-based construction, `ResolverConfig::udp_and_tcp(&GOOGLE)`, and `Lookup::iter()` replaced by `answers()` + an `RData` match. Resolver behavior is preserved (UDP with TCP fallback against Google Public DNS).

**Test race** — `test_audit_session_records_hash_chain` mutated `WAF_DETECTOR_HOME` via `set_var` *without* taking `test_utils::env_lock()`, the mutex every other test touching that variable acquires. Since `set_var` isn't thread-safe, it raced concurrent `env::var` reads and broke `test_consent_status_with_file` about **2 runs in 3**.

## Verification

All run on the toolchain CI uses (1.97.1):

**Ran:** `cargo fmt --all -- --check` · `cargo clippy --all-targets -- -D warnings` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo check --all-targets` · `cargo test` · `cargo test --all-features` · `cargo test --doc` · `cargo audit`
**Proves:** every step passes; `cargo audit` exits 0; `cargo test --lib` green 5/5 consecutive runs (was failing 2 of 3).

**Functional check of the DNS migration** — the record-extraction rewrite is the only change here that can fail *silently* (a wrong `RData` match arm yields an empty vec, not a compile error), so it now has a network test (`#[ignore]`d, since CI has no guaranteed DNS egress). Verified live: `resolve("www.adobe.com")` returns `cnames: ["www.adobe.com.edgesuite.net."]` plus A records — the CNAME arm extracts correctly.

**Pending / not addressed here:**
- Outbound DNS to 8.8.8.8 is blocked in my environment, so the resolver was exercised against the system nameserver to prove the extraction arms; the hardcoded-Google config itself is unchanged and untested from here. Worth knowing that `DnsResolver::resolve()` swallows every lookup error and returns an empty `DnsInfo`, so a network that blocks 8.8.8.8 silently yields no DNS signal at all. Follow-up, not this PR.
- `NS` records come back in the DNS authority section rather than `answers()`, so `ns_records` is empty for subdomains. This matches 0.24's behavior — not a regression from the bump.
- The 8 remaining `cargo audit` findings are informational (unmaintained/unsound/yanked) and don't fail the tool. Two, yanked `js-sys`/`wasm-bindgen`, are pinned by reqwest's wasm-only tree and aren't compiled for any target this project builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)