### PR TITLE
Stop a generic x-request-id header scoring as Imperva

### DIFF
--- a/src/providers/imperva.rs
+++ b/src/providers/imperva.rs
@@ -110,20 +110,6 @@ impl ImpervaProvider {
             }
         }
 
-        // Check X-Request-ID header for Incapsula format
-        if let Some(request_id) = response.headers.get("x-request-id") {
-            // Incapsula request IDs typically have a specific format
-            if request_id.len() > 10 {
-                evidence.push(Evidence {
-                    method_type: MethodType::Header("x-request-id".to_string()),
-                    confidence: 0.70,
-                    description: "Potential Incapsula request ID header".to_string(),
-                    raw_data: request_id.clone(),
-                    signature_matched: "imperva-request-id-header".to_string(),
-                });
-            }
-        }
-
         evidence
     }
 
@@ -296,6 +282,18 @@ mod tests {
     async fn no_evidence_without_imperva_headers() {
         let provider = ImpervaProvider::new();
         let response = mock_response(200, [("server", "nginx")], "");
+        let evidence = provider.passive_detect(&response).await.unwrap();
+        assert!(evidence.is_empty());
+    }
+
+    #[tokio::test]
+    async fn generic_x_request_id_header_is_not_imperva_evidence() {
+        let provider = ImpervaProvider::new();
+        let response = mock_response(
+            200,
+            [("x-request-id", "a1b2c3d4-e5f6-7890-abcd-ef1234567890")],
+            "",
+        );
         let evidence = provider.passive_detect(&response).await.unwrap();
         assert!(evidence.is_empty());
     }


### PR DESCRIPTION
## What

`ImpervaProvider::passive_detect` emitted **0.70-confidence** evidence for *any* response carrying an `x-request-id` header longer than 10 characters, labelled "Potential Incapsula request ID header".

`x-request-id` is not an Imperva header. It's a generic per-request correlation ID emitted by ordinary application stacks — Rails, Express middleware, Spring, Envoy, most API gateways. And a UUID is always longer than 10 characters, so the length check gated nothing. The comment claimed "Incapsula request IDs typically have a specific format" but no format check was ever implemented behind it.

Imperva's real passive signatures (`x-iinfo`, `x-cdn: Incapsula`, the `incap_ses` / `visid_incap` cookies) are untouched and remain the provider's detection basis. A regression test pins the new behavior.

## Verification

**Ran:** `waf-detect scan <url> --json` against a local server whose only distinguishing feature is a generic UUID `X-Request-Id`, with the fix reverted and then reapplied:

```
before:  Imperva score 0.471,  evidence "imperva-request-id-header" (conf 0.70)
after:   Imperva score absent, zero Imperva evidence
```

Also `cargo test --lib providers::imperva` (4 passed) and `cargo fmt --all -- --check`.

**Proves:** the false positive is gone through the real scan path, not just in a unit assertion.

## Blast radius, stated honestly

On that target 0.471 did **not** by itself clear the tier-1 and correlation gates to become the reported `detected_waf` — so this was primarily a `provider_scores` contaminant. But it sat close enough to the line that any second weak Imperva-adjacent signal would carry a target over it, and where it did win it fed `waf_confidence`, which the posture report consumes as evidence that a WAF is present.

## Note

Independent of #55 and #56, but worth sequencing after #56 (which is what gets CI green again — this branch is off `main`, so its Check & Lint and Security Audit jobs will fail for the same pre-existing reasons #56 fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)