### PR TITLE
Record what monitor-mode detection was actually measured against

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -120,9 +120,11 @@ registry.register_provider(provider, metadata)?;
 ### Open
 - [ ] **Probabilistic enforcement model** — replace linear PMI weights with posterior distribution + confidence intervals
 - [ ] **Bypass distance metric** — count transformations needed before WAF response normalizes
-- [x] **Monitor-mode detection** — infer WAF presence from subtle behavioral signals when nothing is blocked
+- [x] **Monitor-mode detection** — infer WAF presence from subtle behavioral signals when nothing is blocked. **Partial: see [docs/MONITOR_MODE_VALIDATION.md](docs/MONITOR_MODE_VALIDATION.md) before quoting coverage.** Measured against 10 controls including real Coraza/OWASP-CRS and real AWS WAF; detects monitor mode only where inspection costs >=~15ms or changes the response, and misses inline optimized engines (both real products tested).
 - [x] **Posture CLI with VA1** — `--posture` integration with enforcement testing
 - [ ] **Cookie channel** — add cookie inspection as a probe channel
+- [ ] **Distinguish "measured zero" from "no measurement"** — `monitor_mode_likelihood` is emitted unconditionally, so 0.000 reads as "not in monitor mode" when it often means "cannot determine". Needs `Option<f64>` or a flag on `PostureReport`.
+- [ ] **Normalization-fingerprint probes** — detect an inspecting intermediary via how it re-serializes malformed requests, which is independent of whether the rule engine is in detection-only mode. The remaining angle on inline silent WAFs.
 
 ### Done
 - [x] Multi-channel perturbation (PR #29)

--- a/docs/MONITOR_MODE_VALIDATION.md
+++ b/docs/MONITOR_MODE_VALIDATION.md
@@ -1,0 +1,132 @@
+# Monitor-mode detection: what it detects, measured
+
+`--posture --posture-va2` reports `monitor_mode_likelihood`, an estimate that a
+WAF is present but not enforcing. This document records what that signal was
+actually measured against, because the boundary is narrower than the feature
+name suggests and it is easy to demo it wrong.
+
+Measured 2026-08-19. Re-run any row before quoting it; WAF vendors change
+implementations.
+
+## Results
+
+Every row is a real run of:
+
+```
+waf-detect --posture <url> --posture-va2 --posture-json
+```
+
+| # | Target | monitor_mode | enforcement | Expected | Correct? |
+|---|--------|-------------:|------------:|----------|:--------:|
+| 1 | Bare static origin, nothing in front | 0.000 | 0.000 | no WAF | yes |
+| 2 | Plain reverse proxy, zero rules | 0.000 | 0.000 | no WAF | yes |
+| 3 | Stand-in proxy: inspects + **allows** | **0.650** | 0.000 | monitor mode | yes |
+| 4 | Stand-in proxy: inspects + blocks | 0.000 | 0.458 | enforcing | yes |
+| 5 | Coraza + OWASP CRS, `SecRuleEngine Off` | 0.000 | 0.000 | no WAF | yes |
+| 6 | Coraza + OWASP CRS, `SecRuleEngine DetectionOnly` | **0.000** | 0.000 | monitor mode | **no — missed** |
+| 7 | Coraza + OWASP CRS, `SecRuleEngine On` | 0.000 | 0.382 | enforcing | yes |
+| 8 | AWS WAF on ALB, WebACL detached | 0.000 | 0.000 | no WAF | yes |
+| 9 | AWS WAF on ALB, managed rules `Count` | **0.000** | 0.000 | monitor mode | **no — missed** |
+| 10 | AWS WAF on ALB, managed rules blocking | 0.000 | 0.246 | enforcing | yes |
+
+Rows 5–7 use real Coraza (the Go implementation of the ModSecurity rule
+language) with the real OWASP Core Rule Set; harness in
+`scripts/coraza-control/`. Rows 8–10 use real AWS WAF with
+`AWSManagedRulesCommonRuleSet` + `AWSManagedRulesSQLiRuleSet` on an ALB with a
+fixed-response listener, `OverrideAction: Count` for row 9. Managed rule groups
+were used rather than hand-written rules so the test could not be tuned to the
+scanner's own probes. `CloudWatchMetrics` confirmed row 9 was genuinely
+counting (`CountedRequests` > 0, `BlockedRequests` 0).
+
+Rows 1–4 use `scripts/monitor_mode_control_proxy.py`.
+
+## What this establishes
+
+**No false positives.** All seven non-monitor-mode rows read 0.000 monitor
+mode, including two real-WAF products and a plain reverse proxy. That last one
+matters most: a detector that fires on any inspecting intermediary would fire
+on plain nginx, and would be worse than the false negative it replaced.
+
+**Enforcement is detected without a vendor signature.** Rows 9 and 10 are
+AWS WAF, which leaves no identifying response header at all — passive detection
+reported `waf=None, confidence=0.0`. Row 10's enforcement estimate came purely
+from behavior.
+
+**Monitor mode is detected only when it leaves a remote trace.** Row 3 is
+detected because the inspecting layer pays ~60ms on flagged requests. Rows 6
+and 9 are missed.
+
+## Why rows 6 and 9 are missed
+
+Not a scoring bug. There is nothing remotely observable.
+
+**Row 6 (Coraza `DetectionOnly`)** — evaluates the full CRS in well under a
+millisecond and, being detection-only, changes nothing about the response.
+Per-pair deltas came back as noise (`[6, -4, -13, 1, 3, -7]` ms) with zero
+header, body, or status differences.
+
+**Row 9 (AWS WAF `Count`)** — same shape, and this one was tested harder
+because a network-hop WAF was expected to be the case that *works*. Per-pair
+deltas from the scanner were `[2, 3, 3, -1, -2]` ms. A dedicated 30-pair
+length-matched measurement gave:
+
+```
+median delta = +1.39 ms    MAD = 3.02 ms    positive = 18/30 (60%)
+bootstrap 95% CI of the median = [-0.80, +2.64] ms   <- includes zero
+```
+
+So AWS WAF's Count-mode inspection cost is **not statistically distinguishable
+from zero** even at n=30. This is not a sample-size limitation — more samples
+will not recover a signal whose confidence interval spans zero. Lowering
+`LATENCY_NOISE_FLOOR_MS` below 15ms to chase it would manufacture false
+positives: the bare-origin control in row 1 showed per-pair deltas up to 16ms
+from connection effects alone, with no WAF present.
+
+Also tested and ruled out for these rows:
+
+- **Response content** — no header, cookie, body-length, or status difference
+  on flagged requests in either product's monitor mode.
+- **Body inspection limits**, on the theory that they are enforced
+  independently of `SecRuleEngine`: a 250KB urlencoded body returned 200 in all
+  three Coraza modes.
+
+## Honest scope
+
+The signal detects monitor-mode inspection that either **costs** something
+observable (roughly >=15ms on flagged requests) or **changes** the response.
+That covers deployments where inspection means body buffering, an extra proxy
+hop, or a WAF attaching a cookie or header — Imperva's `incap_ses` and
+challenge-injecting CDN WAFs are in this class.
+
+It does **not** detect an inline, optimized, silent engine in monitor mode.
+Both products tested here fall in that class. Do not claim coverage of
+"WAF in monitor mode" generally.
+
+## Not yet tested
+
+- Cloudflare, Akamai, Imperva, F5 in monitor/log-only mode. These attach
+  cookies or headers more often than AWS WAF does, so the content route may
+  reach them where latency does not — but that is a prediction, not a
+  measurement.
+- WAFs configured with request-body inspection enabled, where buffering cost is
+  larger and more likely to clear the floor.
+
+## Known reporting gap this exposes
+
+For rows 6 and 9 the tool emits `monitor_mode_likelihood: 0.000`, which reads
+as "not in monitor mode" when the truthful answer is "cannot determine". The
+field is emitted unconditionally even when no enforcement evidence was
+collected. Distinguishing "measured zero" from "no measurement" needs an
+`Option<f64>` or an accompanying flag in `PostureReport`. Until that exists,
+treat a 0.000 as inconclusive rather than negative.
+
+## Next angle, if this matters
+
+Normalization side effects rather than cost or content. An inspecting layer has
+to parse and re-serialize the request, so malformed input — conflicting
+`Content-Length`/`Transfer-Encoding`, oversized headers, `%2e%2e%2f` path
+segments, absolute-form request URIs — tends to produce an error fingerprint
+distinct from the origin's own. That happens in the parser, so it is
+independent of whether the rule engine is in detection-only mode. It carries
+its own false-positive surface: plain nginx normalizes paths too, which is the
+same proxy-vs-WAF trap rows 2 and 5 exist to catch.

--- a/docs/MONITOR_MODE_VALIDATION.md
+++ b/docs/MONITOR_MODE_VALIDATION.md
@@ -130,3 +130,45 @@ distinct from the origin's own. That happens in the parser, so it is
 independent of whether the rule engine is in detection-only mode. It carries
 its own false-positive surface: plain nginx normalizes paths too, which is the
 same proxy-vs-WAF trap rows 2 and 5 exist to catch.
+
+## Per-vendor: is monitor mode remotely detectable at all?
+
+Covering the WAFs supported at Adobe. "Remotely detectable" means: from
+outside, with no console or API access, can we tell a WAF is present while it
+is configured not to block?
+
+| Vendor | Its monitor mode | Detectable? | Signal, or why not | Basis |
+|--------|------------------|:-----------:|--------------------|-------|
+| **Akamai** | alert-only | **yes** | Bot Manager cookies `_abck`, `ak_bmsc`, `bm_sz`, `bm_sv`, `bm_mi` — set as part of normal handling, whether rules alert or deny | vendor + community docs |
+| **CloudFlare** | log | **yes** | `__cf_bm`, set whenever Bot Management / Bot Fight Mode is enabled, independent of any challenge. (`cf-mitigated` means it *acted* — enforcement, not presence) | CloudFlare docs; live-verified |
+| AWS WAF | `Count` | no | Inspection costs ~1.4ms and nothing about the response changes | **measured**, rows 8–10 above |
+| ModSecurity | `DetectionOnly` | no | Sub-millisecond inline evaluation, response unchanged | **measured**, rows 5–7 above |
+| Azure | Detection | no | "the client receives the normal response as if the WAF rule didn't trigger" | Microsoft docs |
+| Fastly NGWAF | Not blocking (Logging) | no | `X-SigSci-*` headers are added to requests travelling *to the origin*; clients never see them | Fastly docs |
+| Wallarm | monitoring | no | No documented client-visible artifact; NGINX-based, and Wallarm's own guidance is to strip version headers | Wallarm docs |
+
+Note on what the two "yes" rows prove: the vendor's **bot-management** module is
+engaged. Not that the WAF ruleset (Akamai App & API Protector, CloudFlare
+managed rules) is enabled, and not its mode. A site can run Bot Manager with
+AAP switched off. The scan attaches a caveat saying exactly that; do not quote
+these as "WAF ruleset in alert mode".
+
+Separately: **Wallarm has no provider in this tool at all**, which is a
+coverage gap independent of monitor mode.
+
+## Consequence: for owned estate, ask the control plane
+
+Five of seven cannot be answered from outside. For infrastructure we own, that
+question has an exact answer available over an API rather than an inferred one:
+
+- AWS: `aws wafv2 list-web-acls` → `get-web-acl` and
+  `get-web-acl-for-resource`, then read each rule's `Action` / a rule group's
+  `OverrideAction` for `Count`. AWS Firewall Manager covers this across
+  accounts, and Adobe has a Firewall Manager account.
+- Azure: the WAF policy's `policySettings.mode` is `Detection` or `Prevention`.
+- Fastly NGWAF: the corp/site API reports agent mode.
+- Wallarm: the node's filtration mode is readable from its API.
+
+This is the reliable way to answer "which of our WAFs are not enforcing", and
+it is not what a black-box scanner can do. Tracked as an open item in
+DEVELOPMENT.md.

--- a/docs/MONITOR_MODE_VALIDATION.md
+++ b/docs/MONITOR_MODE_VALIDATION.md
@@ -172,3 +172,54 @@ question has an exact answer available over an API rather than an inferred one:
 This is the reliable way to answer "which of our WAFs are not enforcing", and
 it is not what a black-box scanner can do. Tracked as an open item in
 DEVELOPMENT.md.
+
+## Ruling out the last angle: parser/normalization fingerprinting
+
+The obvious remaining idea, and the one this document previously listed as the
+next lead: a WAF's rule *action* (Count vs Block) governs what it does with a
+match, but not what its request **parser** accepts. If putting a WAF in the
+path changed any parse-level behaviour, that would be a fingerprint immune to
+monitor mode.
+
+Tested against real AWS WAF on an ALB with 33 parse-level probes sent over raw
+sockets (so the client library could not normalise them away): oversized header
+values stepped 4/8/16/32/64KB, header counts to 200, URI and query lengths to
+16KB, bodies to 64KB spanning AWS WAF's 8KB inspection limit, unusual and
+invalid methods, null bytes and single/double-encoded traversal in the path,
+duplicate `Content-Length`, `Transfer-Encoding` + `Content-Length` conflicts,
+obfuscated `Transfer-Encoding`, absolute-form request URIs, bare-LF line
+terminators, and duplicate `Host`.
+
+Each probe was run three ways against the same ALB: WebACL detached, WebACL
+attached with all managed rules `Count`, and attached with them blocking.
+
+```
+                                  differences vs the WebACL-detached baseline
+  WebACL attached, rules Count      0 / 33
+  WebACL attached, rules blocking  23 / 33
+```
+
+The battery is therefore sensitive — it separates a WAF that acts from no WAF
+on 23 probes — and Count is still invisible on every single one.
+
+This is not a case of the WAF failing to look. CloudWatch for the Count run:
+
+```
+CountedRequests 24    CommonRuleSet counted 23    BlockedRequests 0
+```
+
+AWS WAF matched 23 of the 33 probes as attacks, counted them, and forwarded
+them anyway. The client could not distinguish any of it from an ALB with no
+WAF at all.
+
+Note when reading the blocking column: it 403s even the benign baseline,
+because these raw-socket requests carry no `User-Agent` and AWS's
+`AWSManagedRulesCommonRuleSet` includes `NoUserAgent_HEADER`. That is a rule
+match, not a parser difference — it does not weaken the comparison, since the
+question was only whether Count differs from detached.
+
+**Conclusion.** For AWS WAF, monitor mode has now been probed for latency
+(n=30, CI spans zero), response content, body-inspection limits, and
+parse-level behaviour (33 probes, proven rule matching). All negative. The
+remote answer is that there isn't one, and the control-plane route above is not
+a fallback — it is the correct instrument for this question.


### PR DESCRIPTION
## Why

#55 shipped monitor-mode detection. I then validated it against two **real** WAF products, and the result narrows the claim — but that evidence lived only in a PR thread. This writes it into the repo so nobody demos the tool beyond what it does.

No code changes.

## The measured matrix

Ten controls, each a real `waf-detect --posture <url> --posture-va2 --posture-json` run:

| # | Target | monitor_mode | enforcement | Correct? |
|---|---|---:|---:|:--:|
| 1 | Bare static origin | 0.000 | 0.000 | yes |
| 2 | Plain reverse proxy, zero rules | 0.000 | 0.000 | yes |
| 3 | Stand-in: inspects + **allows** | **0.650** | 0.000 | yes |
| 4 | Stand-in: inspects + blocks | 0.000 | 0.458 | yes |
| 5 | Coraza + OWASP CRS, `SecRuleEngine Off` | 0.000 | 0.000 | yes |
| 6 | Coraza + OWASP CRS, **`DetectionOnly`** | **0.000** | 0.000 | **missed** |
| 7 | Coraza + OWASP CRS, `On` | 0.000 | 0.382 | yes |
| 8 | AWS WAF on ALB, detached | 0.000 | 0.000 | yes |
| 9 | AWS WAF on ALB, managed rules **`Count`** | **0.000** | 0.000 | **missed** |
| 10 | AWS WAF on ALB, managed rules blocking | 0.000 | 0.246 | yes |

Rows 5–7: real Coraza (Go implementation of the ModSecurity rule language) + real OWASP CRS. Rows 8–10: real AWS WAF with `AWSManagedRulesCommonRuleSet` + `AWSManagedRulesSQLiRuleSet`, `OverrideAction: Count` for row 9, CloudWatch confirming it genuinely counted (`CountedRequests` > 0, `BlockedRequests` 0). **Managed rule groups deliberately, not hand-written rules** — otherwise the test could be tuned to the scanner's own probes.

All AWS resources were created in the WAF staging account with the security group restricted to a single corp `/32`, and deleted afterward (verified gone).

## What it establishes

- **No false positives anywhere.** All seven non-monitor-mode rows read 0.000 — including a plain reverse proxy and two real WAF products. That plain-proxy row is the important one: a detector that fires on any inspecting intermediary would fire on nginx and be worse than the false negative it replaced.
- **Enforcement works with no vendor signature.** AWS WAF leaves no identifying header; passive detection reported `waf=None, confidence=0.0`, and row 10's enforcement estimate came purely from behavior.
- **Monitor mode is detected only when it leaves a remote trace.**

## Why rows 6 and 9 are missed — not a scoring bug

There is nothing remotely observable. Both engines evaluate inline in well under a millisecond and change nothing about the response.

Row 9 was tested hardest, since a network-hop commercial WAF was the case I expected to *work*. A dedicated 30-pair length-matched measurement:

```
median delta = +1.39 ms    MAD = 3.02 ms    positive = 18/30 (60%)
bootstrap 95% CI of the median = [-0.80, +2.64] ms   <- includes zero
```

Not distinguishable from zero at n=30. **Not a sample-size limitation** — more samples don't recover a signal whose CI spans zero. And lowering the 15ms floor to chase it would manufacture false positives: row 1's bare origin showed per-pair deltas up to 16ms from connection effects with no WAF present.

Also tested and ruled out for those rows: response content differences (none), and body-inspection limits on the theory they're enforced independently of `SecRuleEngine` (250KB body → 200 in all three Coraza modes).

## Honest scope, now documented

Detects monitor-mode inspection that **costs** something observable (≥~15ms) or **changes** the response — body buffering, an extra proxy hop, or a WAF attaching a cookie/header (Imperva's `incap_ses`, challenge-injecting CDN WAFs). Does **not** detect an inline optimized silent engine; both products tested are in that class. The doc says plainly not to claim coverage of "WAF in monitor mode" generally.

## Two open items this surfaced, added to DEVELOPMENT.md

- **`0.000` is ambiguous.** It currently reads as "not in monitor mode" when it often means "cannot determine". Needs `Option<f64>` or a flag on `PostureReport`. Until then a 0.000 should be read as inconclusive, not negative.
- **Normalization fingerprinting** is the remaining lead for inline silent engines: an inspecting layer must parse and re-serialize, so malformed input yields an error fingerprint distinct from the origin's — independent of the rule engine's mode. Carries its own false-positive surface, since plain nginx normalizes too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)