### PR TITLE
Detect Akamai and CloudFlare security modules when nothing is blocked

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -259,7 +259,30 @@ impl HttpClient {
         let mut headers = HashMap::new();
         for (name, value) in response.headers() {
             if let Ok(value_str) = value.to_str() {
-                headers.insert(name.to_string().to_lowercase(), value_str.to_string());
+                let key = name.to_string().to_lowercase();
+                // A response can carry many Set-Cookie headers, and a plain
+                // `insert` keeps only the last one. That silently defeats every
+                // cookie-based signature: www.cloudflare.com returns five
+                // Set-Cookie headers and the `__cf_bm` bot-management cookie is
+                // not reliably among the last, so detection depended on header
+                // ordering. Accumulate them instead, newline-separated because
+                // cookie values legitimately contain commas (`Expires=...`) and
+                // comma-joining would corrupt them.
+                //
+                // Restricted to set-cookie on purpose: for every other header,
+                // last-wins is the pre-existing behavior and consumers may parse
+                // the value as a single scalar.
+                if key == "set-cookie" {
+                    headers
+                        .entry(key)
+                        .and_modify(|existing: &mut String| {
+                            existing.push('\n');
+                            existing.push_str(value_str);
+                        })
+                        .or_insert_with(|| value_str.to_string());
+                } else {
+                    headers.insert(key, value_str.to_string());
+                }
             }
         }
 
@@ -294,6 +317,46 @@ impl HttpClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Multiple Set-Cookie headers must all survive into `HttpResponse`.
+    ///
+    /// They previously did not: each was `insert`ed into the same map key, so
+    /// only the last one remained. Every cookie-based signature therefore
+    /// depended on header ordering -- www.cloudflare.com returns five
+    /// Set-Cookie headers, and its `__cf_bm` bot-management cookie is not
+    /// reliably last.
+    #[tokio::test]
+    async fn accumulates_every_set_cookie_header() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/")
+            .with_status(200)
+            .with_header("set-cookie", "first=1; Path=/")
+            .with_header("set-cookie", "__cf_bm=abc123; Path=/; HttpOnly")
+            .with_header("set-cookie", "last=2; Path=/")
+            .with_body("ok")
+            .create_async()
+            .await;
+
+        let client = HttpClient::new().expect("client");
+        let response = client.get(&server.url()).await.expect("request");
+        mock.assert_async().await;
+
+        let cookies = response
+            .headers
+            .get("set-cookie")
+            .expect("set-cookie must be captured");
+        for expected in ["first=1", "__cf_bm=abc123", "last=2"] {
+            assert!(
+                cookies.contains(expected),
+                "lost {expected} from the accumulated Set-Cookie value: {cookies:?}"
+            );
+        }
+        // Newline-separated, because cookie values contain commas in `Expires`
+        // and comma-joining would corrupt them.
+        assert_eq!(cookies.lines().count(), 3, "got {cookies:?}");
+    }
+
     use crate::surface::{AuthHeaderValue, AuthProfile, RouteAuthHeaders};
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,31 @@ impl DetectionResult {
             }
         }
 
+        // Caveat: bot-management evidence proves a security module is engaged,
+        // which is valuable precisely because it survives a WAF configured to
+        // log rather than block -- but it does not establish that the vendor's
+        // WAF ruleset is enabled, nor its mode. Say so, rather than letting the
+        // confidence number imply more than the cookie supports.
+        let mut bot_management_providers: Vec<&String> = self
+            .evidence_map
+            .iter()
+            .filter(|(_, evidence)| {
+                evidence.iter().any(|e| {
+                    e.signature_matched == "akamai-bot-manager-cookie"
+                        || e.signature_matched == "cloudflare-bot-management-cookie"
+                })
+            })
+            .map(|(provider, _)| provider)
+            .collect();
+        bot_management_providers.sort();
+        for provider in bot_management_providers {
+            caveats.push(format!(
+                "{provider} bot-management signals confirm a security module is in the request \
+                 path even if nothing was blocked; whether the WAF ruleset is enabled, and \
+                 whether it alerts or denies, cannot be determined remotely"
+            ));
+        }
+
         self.caveats = caveats;
     }
 
@@ -671,6 +696,51 @@ mod tests {
         assert_eq!(result.caveats.len(), 1);
         assert!(result.caveats[0].contains("body patterns only"));
         assert!(result.caveats[0].contains("ModSecurity"));
+    }
+
+    #[test]
+    fn generate_caveats_flags_bot_management_scope_limit() {
+        // Bot-management evidence is the one signal that survives a WAF set to
+        // log rather than block, so it is load-bearing -- which is exactly why
+        // the result has to say out loud what it does not prove.
+        let mut result = DetectionResult {
+            url: "https://example.com".to_string(),
+            detected_waf: Some(ProviderDetection {
+                name: "Akamai".to_string(),
+                confidence: 0.9,
+            }),
+            detected_cdn: None,
+            provider_scores: HashMap::new(),
+            evidence_map: HashMap::from([(
+                "Akamai".to_string(),
+                vec![Evidence {
+                    method_type: MethodType::Header("set-cookie".to_string()),
+                    confidence: 0.9,
+                    description: "Akamai Bot Manager cookie '_abck'".to_string(),
+                    raw_data: "_abck".to_string(),
+                    signature_matched: "akamai-bot-manager-cookie".to_string(),
+                }],
+            )]),
+            evidence: vec![],
+            detection_time_ms: 1,
+            metadata: DetectionMetadata {
+                timestamp: chrono::Utc::now(),
+                version: "0.1.0".to_string(),
+                user_agent: "test".to_string(),
+            },
+            caveats: vec![],
+            security_posture: None,
+            error: None,
+        };
+        result.generate_caveats();
+        assert!(
+            result
+                .caveats
+                .iter()
+                .any(|c| c.contains("cannot be determined remotely")),
+            "expected a caveat bounding what bot-management evidence proves, got {:?}",
+            result.caveats
+        );
     }
 
     #[test]

--- a/src/providers/akamai.rs
+++ b/src/providers/akamai.rs
@@ -52,6 +52,55 @@ impl AkamaiProvider {
         PATTERN.get_or_init(|| Regex::new(r"^x-akamai-").unwrap())
     }
 
+    /// Cookies set by Akamai's security module, as opposed to plain delivery.
+    ///
+    /// These matter for a specific question the rest of this tool struggles
+    /// with: whether a WAF is present when it is *not* blocking anything.
+    /// Akamai sets these as part of Bot Manager's normal request handling, so
+    /// they appear whether its rules are configured to alert or to deny --
+    /// unlike a block page, which only appears when something is denied.
+    ///
+    /// Scope, deliberately narrow: this proves Akamai's **Bot Manager** is in
+    /// the request path. It does *not* prove App & API Protector (the WAF
+    /// ruleset) is enabled, and it says nothing about that ruleset's mode. A
+    /// site can run Bot Manager with AAP switched off entirely.
+    /// `DetectionResult::generate_caveats` attaches that qualification to the
+    /// result so the distinction survives into the report.
+    ///
+    /// Names per Akamai Bot Manager behavior: `_abck` (long-lived risk score),
+    /// `ak_bmsc` and `bm_sz` (session), `bm_sv` and `bm_mi` (secondary).
+    pub fn check_security_module_cookies(
+        &self,
+        response: &crate::http::HttpResponse,
+    ) -> Vec<Evidence> {
+        let mut evidence = Vec::new();
+        let Some(raw) = response.headers.get("set-cookie") else {
+            return evidence;
+        };
+        let haystack = raw.to_ascii_lowercase();
+
+        for cookie in ["_abck", "ak_bmsc", "bm_sz", "bm_sv", "bm_mi"] {
+            // Match `name=` so a bare substring elsewhere in the header cannot
+            // trigger this.
+            if haystack.contains(&format!("{cookie}=")) {
+                evidence.push(Evidence {
+                    method_type: MethodType::Header("set-cookie".to_string()),
+                    confidence: 0.90,
+                    description: format!(
+                        "Akamai Bot Manager cookie '{cookie}' — Akamai's security module is \
+                         handling this request, and does so whether its rules alert or deny. \
+                         Does not establish that the App & API Protector WAF ruleset is enabled \
+                         or which mode it is in."
+                    ),
+                    raw_data: cookie.to_string(),
+                    signature_matched: "akamai-bot-manager-cookie".to_string(),
+                });
+            }
+        }
+
+        evidence
+    }
+
     pub async fn check_headers(&self, response: &crate::http::HttpResponse) -> Vec<Evidence> {
         let mut evidence = Vec::new();
 
@@ -233,20 +282,17 @@ impl DetectionProvider for AkamaiProvider {
     }
 
     async fn detect(&self, context: &DetectionContext) -> Result<Vec<Evidence>> {
+        // Delegates to `passive_detect` rather than repeating its checks.
+        //
+        // These two used to run the same three checks side by side, and the
+        // registry calls `detect`, not `passive_detect`. That meant a check
+        // added to only one of them compiled, passed its unit tests, and then
+        // silently never ran against a live target -- which is exactly what
+        // happened when the security-module cookie check was added below.
         let mut all_evidence = Vec::new();
 
         if let Some(response) = &context.response {
-            // Check headers
-            let header_evidence = self.check_headers(response).await;
-            all_evidence.extend(header_evidence);
-
-            // Check body patterns
-            let body_evidence = self.check_body_patterns(response).await;
-            all_evidence.extend(body_evidence);
-
-            // Check status codes
-            let status_evidence = self.check_status_codes(response).await;
-            all_evidence.extend(status_evidence);
+            all_evidence.extend(self.passive_detect(response).await?);
         }
 
         Ok(all_evidence)
@@ -256,6 +302,7 @@ impl DetectionProvider for AkamaiProvider {
         let mut all_evidence = Vec::new();
 
         all_evidence.extend(self.check_headers(response).await);
+        all_evidence.extend(self.check_security_module_cookies(response));
         all_evidence.extend(self.check_body_patterns(response).await);
         all_evidence.extend(self.check_status_codes(response).await);
 
@@ -273,6 +320,86 @@ impl Default for AkamaiProvider {
 mod tests {
     use super::*;
     use crate::providers::test_utils::mock_response;
+
+    #[tokio::test]
+    async fn detects_akamai_bot_manager_cookie_without_any_block() {
+        // The case this exists for: an ordinary 200 with no block page, no
+        // security header, nothing denied -- but Akamai's security module has
+        // still stamped the response.
+        let provider = AkamaiProvider::new();
+        let response = mock_response(
+            200,
+            [(
+                "set-cookie",
+                "_abck=7A2F1B~-1~YAAQ...~-1~-1~-1; Path=/; Domain=.example.com",
+            )],
+            "<html>ordinary page</html>",
+        );
+        let evidence = provider.passive_detect(&response).await.unwrap();
+        let bm: Vec<_> = evidence
+            .iter()
+            .filter(|e| e.signature_matched == "akamai-bot-manager-cookie")
+            .collect();
+        assert_eq!(bm.len(), 1, "expected one Bot Manager cookie hit");
+        // The description must carry the scope limit, since the confidence
+        // number alone would overstate what a cookie proves.
+        assert!(
+            bm[0].description.contains("App & API Protector"),
+            "evidence must state that the WAF ruleset is not established: {}",
+            bm[0].description
+        );
+    }
+
+    #[tokio::test]
+    async fn detects_multiple_akamai_bot_manager_cookies() {
+        let provider = AkamaiProvider::new();
+        let response = mock_response(
+            200,
+            [("set-cookie", "ak_bmsc=ABC123; Path=/, bm_sz=DEF456; Path=/")],
+            "",
+        );
+        let evidence = provider.passive_detect(&response).await.unwrap();
+        let hits: Vec<&str> = evidence
+            .iter()
+            .filter(|e| e.signature_matched == "akamai-bot-manager-cookie")
+            .map(|e| e.raw_data.as_str())
+            .collect();
+        assert!(hits.contains(&"ak_bmsc"), "got {hits:?}");
+        assert!(hits.contains(&"bm_sz"), "got {hits:?}");
+    }
+
+    #[tokio::test]
+    async fn unrelated_cookies_are_not_bot_manager_evidence() {
+        // A cookie name that merely *contains* a fragment must not match, and
+        // an ordinary session cookie must not either.
+        let provider = AkamaiProvider::new();
+        let response = mock_response(
+            200,
+            [(
+                "set-cookie",
+                "session=abc; my_abck_lookalike_note=1; visitor_bm_szone=x",
+            )],
+            "",
+        );
+        let evidence = provider.passive_detect(&response).await.unwrap();
+        assert!(
+            !evidence
+                .iter()
+                .any(|e| e.signature_matched == "akamai-bot-manager-cookie"),
+            "must not fire on cookies that merely embed the name: {:?}",
+            evidence.iter().map(|e| &e.raw_data).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn no_cookies_means_no_bot_manager_evidence() {
+        let provider = AkamaiProvider::new();
+        let response = mock_response(200, [("content-type", "text/html")], "");
+        let evidence = provider.passive_detect(&response).await.unwrap();
+        assert!(!evidence
+            .iter()
+            .any(|e| e.signature_matched == "akamai-bot-manager-cookie"));
+    }
 
     #[tokio::test]
     async fn detects_akamai_server_header() {

--- a/src/providers/cloudflare.rs
+++ b/src/providers/cloudflare.rs
@@ -15,6 +15,59 @@ pub struct CloudFlareProvider {
 }
 
 impl CloudFlareProvider {
+    /// CloudFlare signals that indicate its security layer is engaged, as
+    /// distinct from `cf-ray`/`server: cloudflare`, which only say traffic is
+    /// proxied through CloudFlare.
+    ///
+    /// Two different claims, deliberately kept apart:
+    ///
+    /// - `__cf_bm` is set on ordinary requests whenever Bot Management or Bot
+    ///   Fight Mode is enabled, *whether or not* any challenge or block
+    ///   occurs. That makes it one of the few signals that survives a WAF
+    ///   configured to log rather than act. It does not establish that
+    ///   CloudFlare's WAF managed rules are enabled, nor their mode --
+    ///   `DetectionResult::generate_caveats` attaches that qualification.
+    /// - `cf-mitigated` appears when CloudFlare actually acted on the request
+    ///   (e.g. `cf-mitigated: challenge`). That is evidence of *enforcement*,
+    ///   not merely of presence, so it is described as such.
+    pub fn check_security_module_signals(
+        &self,
+        response: &crate::http::HttpResponse,
+    ) -> Vec<Evidence> {
+        let mut evidence = Vec::new();
+
+        if let Some(raw) = response.headers.get("set-cookie") {
+            if raw.to_ascii_lowercase().contains("__cf_bm=") {
+                evidence.push(Evidence {
+                    method_type: MethodType::Header("set-cookie".to_string()),
+                    confidence: 0.90,
+                    description: "CloudFlare Bot Management cookie '__cf_bm' — CloudFlare's \
+                                  security layer is handling this request, and sets this whether \
+                                  or not it challenges or blocks. Does not establish that the \
+                                  WAF managed rules are enabled or which mode they are in."
+                        .to_string(),
+                    raw_data: "__cf_bm".to_string(),
+                    signature_matched: "cloudflare-bot-management-cookie".to_string(),
+                });
+            }
+        }
+
+        if let Some(mitigated) = response.headers.get("cf-mitigated") {
+            evidence.push(Evidence {
+                method_type: MethodType::Header("cf-mitigated".to_string()),
+                confidence: 0.95,
+                description: format!(
+                    "CloudFlare cf-mitigated: {mitigated} — CloudFlare took action on this \
+                     request. This is evidence of active enforcement, not merely presence."
+                ),
+                raw_data: mitigated.clone(),
+                signature_matched: "cloudflare-mitigated-header".to_string(),
+            });
+        }
+
+        evidence
+    }
+
     pub fn new() -> Self {
         Self {
             name: "CloudFlare".to_string(),
@@ -251,20 +304,17 @@ impl DetectionProvider for CloudFlareProvider {
     }
 
     async fn detect(&self, context: &DetectionContext) -> Result<Vec<Evidence>> {
+        // Delegates to `passive_detect` rather than repeating its checks.
+        //
+        // These two used to run the same three checks side by side, and the
+        // registry calls `detect`, not `passive_detect`. That meant a check
+        // added to only one of them compiled, passed its unit tests, and then
+        // silently never ran against a live target -- which is exactly what
+        // happened when the security-module cookie check was added below.
         let mut all_evidence = Vec::new();
 
         if let Some(response) = &context.response {
-            // Check headers
-            let header_evidence = self.check_headers(response).await;
-            all_evidence.extend(header_evidence);
-
-            // Check body patterns
-            let body_evidence = self.check_body_patterns(response).await;
-            all_evidence.extend(body_evidence);
-
-            // Check status codes
-            let status_evidence = self.check_status_codes(response).await;
-            all_evidence.extend(status_evidence);
+            all_evidence.extend(self.passive_detect(response).await?);
         }
 
         Ok(all_evidence)
@@ -274,6 +324,7 @@ impl DetectionProvider for CloudFlareProvider {
         let mut all_evidence = Vec::new();
 
         all_evidence.extend(self.check_headers(response).await);
+        all_evidence.extend(self.check_security_module_signals(response));
         all_evidence.extend(self.check_body_patterns(response).await);
         all_evidence.extend(self.check_status_codes(response).await);
 
@@ -291,6 +342,70 @@ impl Default for CloudFlareProvider {
 mod tests {
     use super::*;
     use crate::providers::test_utils::mock_response;
+
+    #[tokio::test]
+    async fn detects_cf_bm_cookie_without_any_block() {
+        // A plain 200 with no challenge and nothing blocked, but CloudFlare's
+        // bot layer has stamped the response -- which it does regardless of
+        // whether it acts.
+        let provider = CloudFlareProvider::new();
+        let response = mock_response(
+            200,
+            [(
+                "set-cookie",
+                "__cf_bm=abc123def456; path=/; HttpOnly; Secure",
+            )],
+            "<html>ordinary page</html>",
+        );
+        let evidence = provider.passive_detect(&response).await.unwrap();
+        let bm: Vec<_> = evidence
+            .iter()
+            .filter(|e| e.signature_matched == "cloudflare-bot-management-cookie")
+            .collect();
+        assert_eq!(bm.len(), 1);
+        assert!(
+            bm[0].description.contains("managed rules"),
+            "evidence must state the WAF ruleset is not established: {}",
+            bm[0].description
+        );
+    }
+
+    #[tokio::test]
+    async fn cf_mitigated_header_is_reported_as_enforcement_not_presence() {
+        let provider = CloudFlareProvider::new();
+        let response = mock_response(200, [("cf-mitigated", "challenge")], "");
+        let evidence = provider.passive_detect(&response).await.unwrap();
+        let hit = evidence
+            .iter()
+            .find(|e| e.signature_matched == "cloudflare-mitigated-header")
+            .expect("expected cf-mitigated evidence");
+        assert!(
+            hit.description.contains("active enforcement"),
+            "cf-mitigated means CloudFlare acted, and must be described that way: {}",
+            hit.description
+        );
+    }
+
+    #[tokio::test]
+    async fn cf_ray_alone_is_not_bot_management_evidence() {
+        // cf-ray proves traffic is proxied through CloudFlare, nothing more.
+        // It must not be conflated with the security layer being engaged.
+        let provider = CloudFlareProvider::new();
+        let response = mock_response(
+            200,
+            [("cf-ray", "7d4f8a1b2c3d4e5f-SJC"), ("server", "cloudflare")],
+            "",
+        );
+        let evidence = provider.passive_detect(&response).await.unwrap();
+        assert!(!evidence.iter().any(|e| {
+            e.signature_matched == "cloudflare-bot-management-cookie"
+                || e.signature_matched == "cloudflare-mitigated-header"
+        }));
+        assert!(
+            !evidence.is_empty(),
+            "cf-ray should still identify CloudFlare"
+        );
+    }
 
     #[tokio::test]
     async fn detects_cf_ray_header() {


### PR DESCRIPTION
## What

Adds the signals that survive a WAF configured to **log rather than act** — for the two supported vendors where such a signal provably exists. The tool looked for none of them before.

- Akamai Bot Manager cookies: `_abck`, `ak_bmsc`, `bm_sz`, `bm_sv`, `bm_mi`
- CloudFlare `__cf_bm`, set whenever Bot Management / Bot Fight Mode is on, independent of any challenge
- CloudFlare `cf-mitigated`, which is different in kind — it appears only when CloudFlare *acted*, so it's reported as evidence of **enforcement**, not presence

## Why only these two of the seven

I measured or documented all seven supported vendors (full matrix in #58):

| Vendor | Monitor mode | Remotely detectable when not blocking? | Basis |
|---|---|:--:|---|
| **Akamai** | alert-only | **yes** | Bot Manager cookies, set regardless of action |
| **CloudFlare** | log | **yes** | `__cf_bm`, set regardless of challenge |
| AWS WAF | Count | no | **measured**: +1.39ms median, bootstrap 95% CI `[-0.80, +2.64]` spans zero |
| ModSecurity | DetectionOnly | no | **measured** via Coraza + real OWASP CRS |
| Azure | Detection | no | MS docs: "the client receives the normal response as if the WAF rule didn't trigger" |
| Fastly NGWAF | Not blocking | no | `X-SigSci-*` travel origin-ward, invisible to clients |
| Wallarm | monitoring | no | no documented client-visible artifact — **and no provider exists at all** (separate gap) |

## Scope, enforced in the output not just in comments

These cookies prove the vendor's **bot-management** module is engaged. They do **not** prove the WAF ruleset (Akamai App & API Protector, CloudFlare managed rules) is enabled, and say nothing about its mode — a site can run Bot Manager with AAP switched off.

Rather than let a 0.90 confidence imply more than a cookie supports, `generate_caveats` attaches: *"…whether the WAF ruleset is enabled, and whether it alerts or denies, cannot be determined remotely."* The evidence descriptions carry the same limit and tests assert on it.

## Two bugs found while verifying, both load-bearing

**Multiple `Set-Cookie` headers were collapsed.** `response_to_http_response` `insert`ed each into one map key, so only the last survived — every cookie-based signature depended on header ordering. `www.cloudflare.com` returns five `Set-Cookie` headers and `__cf_bm` is not reliably last. This also silently weakened the pre-existing F5 `BIGipServer` signature. Now accumulated newline-separated (not comma-joined — cookie values contain commas in `Expires`). Hermetic mockito test added.

**`detect` and `passive_detect` duplicated their checks.** The registry calls `detect`. Adding the cookie check to `passive_detect` alone compiled, passed its unit tests, and **never ran against a live target** — caught only because the live scan stayed silent while tests were green. Both providers' `detect` now delegates to `passive_detect`, removing the trap rather than working around it.

## Verification

`waf-detect scan <url> --json` — passive, no attack payloads:

| target | security-module signal | scope caveat |
|---|---|:--:|
| synthetic origin, both cookie families | `akamai-bot-manager-cookie` + `cloudflare-bot-management-cookie` | yes |
| **www.cloudflare.com** (live) | `cloudflare-bot-management-cookie` | yes |
| www.fastly.com (live, negative) | none | no |

**Proves:** the CloudFlare path works end-to-end against a real deployment and doesn't fire on a different CDN.

**Pending — the Akamai path is not live-verified.** It passes unit tests and works against a synthetic origin through the real CLI, but neither the Adobe properties I checked nor two retail sites returned `_abck` on a plain GET (likely gated behind their JS challenge flow). I deliberately did **not** point the full scan at third parties, since it sends sqlmap/Nikto User-Agent probes. Closing this needs an Adobe property with Bot Manager enabled — happy to run it against one.

Also: `cargo test` (16 suites, 405 lib tests), `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo audit` — all clean.

## What this does not do

For AWS, Azure, ModSec, Fastly and Wallarm, "is the WAF in monitor mode" is not a remotely answerable question — that's measured, not assumed. For **owned** estate the reliable answer is the control plane: `aws wafv2 get-web-acl-for-resource` and Firewall Manager report which WebACLs have rules in `Count` with certainty. That's a new command surface and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)